### PR TITLE
Remove redundant publishing condition

### DIFF
--- a/instagram_private_api/endpoints/upload.py
+++ b/instagram_private_api/endpoints/upload.py
@@ -404,9 +404,6 @@ class UploadEndpointsMixin(object):
                 raise ValueError('Incompatible aspect ratio.')
             if to_reel and not self.reel_compatible_aspect_ratio(size):
                 raise ValueError('Incompatible reel aspect ratio.')
-            if not 320 <= size[0] <= 1080:
-                # range from https://help.instagram.com/1631821640426723
-                raise ValueError('Invalid image width.')
 
         location = kwargs.pop('location', None)
         if location:


### PR DESCRIPTION
Scaling logic was is moved to the backend server. Instagram will scale images to the optimal width anyway.
